### PR TITLE
RIA-6829 update FT for ada list case when create hearing bundle v2

### DIFF
--- a/src/functionalTest/resources/scenarios/ia/IA-RIA-6829-ada-listCase-with-awaitingRespondentEvidence-postEventState-should-create-a-task.json
+++ b/src/functionalTest/resources/scenarios/ia/IA-RIA-6829-ada-listCase-with-awaitingRespondentEvidence-postEventState-should-create-a-task.json
@@ -1,5 +1,5 @@
 {
-  "description": "listCase with ADA prepareForHearing post event state should create a adaCaseSummaryHearingBundleStartDecision task",
+  "description": "listCase with ADA awaitingRespondentEvidence post event state should create a adaCaseSummaryHearingBundleStartDecision task",
   "enabled": true,
   "jurisdiction": "IA",
   "caseType": "Asylum",
@@ -33,7 +33,7 @@
             "template": "minimal-ccd-event-message.json",
             "replacements": {
               "EventId": "listCase",
-              "NewStateId": "prepareForHearing",
+              "NewStateId": "awaitingRespondentEvidence",
               "AdditionalData": {
                 "Data": {
                   "appealType": "protection",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6829


### Change description ###
-update the functional test after changing post event state for new ADA task "ADA-Create Hearing Bundle"


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
