### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ repositories {
 def versions = [
         junit           : '5.7.1',
         junitPlatform   : '1.7.1',
-        reformLogging   : '5.1.9',
+        reformLogging   : '6.0.1',
         springfoxSwagger: '3.0.0',
         serenity        : '2.2.12',
         tomcat          : '9.0.58'


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.