### PR TITLE
RIA-7790 list the case work allocation task is created when hearing is adjourned

### DIFF
--- a/src/functionalTest/resources/scenarios/ia/IA-RIA-7790-recordAdjournmentDetails-with-hearingAdjournmentWhen-and-relistCaseImmediately-should-create-listTheCase-task.json
+++ b/src/functionalTest/resources/scenarios/ia/IA-RIA-7790-recordAdjournmentDetails-with-hearingAdjournmentWhen-and-relistCaseImmediately-should-create-listTheCase-task.json
@@ -1,0 +1,140 @@
+{
+  "description": "recordAdjournmentDetails with hearingAdjournmentWhen and relistCaseImmediately should create listTheCase task",
+  "enabled": true,
+  "jurisdiction": "IA",
+  "caseType": "Asylum",
+  "options": {
+    "taskRetrievalApi": "task-management-api"
+  },
+  "required": {
+    "credentials": "IALegalRepresentative",
+    "ccd": [
+      {
+        "eventId": "recordAdjournmentDetails",
+        "state": "listing",
+        "caseData": {
+          "template": "minimal-appeal-started.json",
+          "replacements": {
+            "appealType": "protection"
+          }
+        }
+      }
+    ]
+  },
+  "test": {
+    "request": {
+      "credentials": "AdminOfficer",
+      "input": {
+        "eventMessages": [
+          {
+            "template": "minimal-ccd-event-message.json",
+            "replacements": {
+              "EventId": "recordAdjournmentDetails",
+              "NewStateId": "listing",
+              "AdditionalData": {
+                "Data": {
+                  "appealType": "protection",
+                  "hearingAdjournmentWhen": "onHearingDate",
+                  "relistCaseImmediately": true
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "expectations": [
+      {
+        "credentials": "CTSCAdmin",
+        "status": 200,
+        "numberOfTasksAvailable": 1,
+        "taskTypes": ["listTheCase"],
+        "taskData": {
+          "template": "minimal-task-response.json",
+          "replacements": {
+            "tasks": [
+              {
+                "id": "{$VERIFIER-UUID}",
+                "case_name": "Functional PostDeployment",
+                "case_id": "{$GENERATED_CASE_ID}",
+                "case_category": "Protection",
+                "name": "List the case",
+                "type": "listTheCase",
+                "task_state": "unassigned",
+                "task_system": "SELF",
+                "security_classification": "PUBLIC",
+                "task_title": "List the case",
+                "created_date": "{$VERIFIER-ZONED_DATETIME_TODAY}",
+                "due_date": "{$VERIFIER-ZONED_DATETIME_TODAY+2_WORKING_DAYS}",
+                "execution_type": "Case Management Task",
+                "jurisdiction": "IA",
+                "case_type_id": "Asylum",
+                "region": "1",
+                "location": "765324",
+                "location_name": "Taylor House",
+                "auto_assigned": false,
+                "warnings": false,
+                "role_category": "CTSC",
+                "warning_list": {
+                  "values": [
+
+                  ]
+                },
+                "case_management_category": "Protection",
+                "work_type_id": "hearing_work",
+                "permissions": {
+                  "values": [
+                    "Read",
+                    "Own","Claim",
+                    "Manage","Unassign","Assign","Complete",
+                    "Cancel"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "numberOfRolesAvailable": 3,
+        "roleData": {
+          "roles":[
+            {
+              "role_category":"CTSC",
+              "role_name":"ctsc",
+              "permissions":[
+                "Read",
+                "Own","Claim",
+                "Manage","Unassign","Assign","Complete",
+                "Cancel"
+              ],
+              "authorisations":[
+              ]
+            },
+            {
+              "role_category":"CTSC",
+              "role_name":"ctsc-team-leader",
+              "permissions":[
+                "Read",
+                "Own","Claim",
+                "Manage","Unassign","Assign","Complete",
+                "Cancel"
+              ],
+              "authorisations":[
+              ]
+            },
+            {
+              "role_name":"task-supervisor",
+              "permissions":[
+                "Read",
+                "Manage","Unassign","Assign","Complete",
+                "Execute","Claim",
+                "Cancel"
+              ],
+              "authorisations":[
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/ia/IA-RWA-000-prepareForHearing-postEventState-should-create-a-task.json
+++ b/src/functionalTest/resources/scenarios/ia/IA-RWA-000-prepareForHearing-postEventState-should-create-a-task.json
@@ -91,9 +91,9 @@
                 }
               },
               {
-                "name": "Post hearing – attendees, duration and recording",
+                "name": "Post hearing – attendees,duration and recording",
                 "type": "postHearingAttendeesDurationAndRecording",
-                "task_title": "Post hearing – attendees, duration and recording",
+                "task_title": "Post hearing – attendees,duration and recording",
                 "id": "{$VERIFIER-UUID}",
                 "case_name": "Functional PostDeployment",
                 "case_id": "{$GENERATED_CASE_ID}",

--- a/src/functionalTest/resources/scenarios/ia/IA-RWA-000-prepareForHearing-postEventState-should-create-a-task.json
+++ b/src/functionalTest/resources/scenarios/ia/IA-RWA-000-prepareForHearing-postEventState-should-create-a-task.json
@@ -48,7 +48,7 @@
         "credentials": "IACaseworker",
         "status": 200,
         "numberOfTasksAvailable": 2,
-        "taskTypes": ["caseSummaryHearingBundleStartDecision", "uploadHearingRecording"],
+        "taskTypes": ["caseSummaryHearingBundleStartDecision", "postHearingAttendeesDurationAndRecording"],
         "taskData": {
           "template": "minimal-task-response.json",
           "replacements": {
@@ -91,9 +91,9 @@
                 }
               },
               {
-                "name": "Upload hearing recording",
-                "type": "uploadHearingRecording",
-                "task_title": "Upload hearing recording",
+                "name": "Post hearing – attendees, duration and recording",
+                "type": "postHearingAttendeesDurationAndRecording",
+                "task_title": "Post hearing – attendees, duration and recording",
                 "id": "{$VERIFIER-UUID}",
                 "case_name": "Functional PostDeployment",
                 "case_id": "{$GENERATED_CASE_ID}",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7790


### Change description ###
- Added the functional test for "List the case" work allocation task when "Record adjournment details" event is completed with following condition:
  1. if set "When did the adjournment happen?" question to "On the day of the hearing"
  2. if set "Can the case be relisted right away?" question to "Yes"
- Updated the functional test (IA-RWA-000-prepareForHearing-postEventState-should-create-a-task) because of someone PR (https://github.com/hmcts/ia-task-configuration/pull/335) 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
